### PR TITLE
Dotnet uplift

### DIFF
--- a/Chernobyl Relay Chat/App.config
+++ b/Chernobyl Relay Chat/App.config
@@ -1,13 +1,13 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
     </configSections>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-            <probing privatePath="lib" />
+            <probing privatePath="lib"/>
         </assemblyBinding>
     </runtime>
 </configuration>

--- a/Chernobyl Relay Chat/CRCOptions.cs
+++ b/Chernobyl Relay Chat/CRCOptions.cs
@@ -13,8 +13,8 @@ namespace Chernobyl_Relay_Chat
 #else
         private static RegistryKey registry = Registry.CurrentUser.CreateSubKey(@"Software\Chernobyl Relay Chat");
 #endif
-
-        public const string Server = "irc.slashnet.org";
+        //irc.slashnet.org
+        public const string Server = "irc.libera.chat";
         public const string InPath = @"\..\gamedata\configs\crc_input.txt";
         public const string OutPath = @"\..\gamedata\configs\crc_output.txt";
 

--- a/Chernobyl Relay Chat/CRCStrings.cs
+++ b/Chernobyl Relay Chat/CRCStrings.cs
@@ -23,11 +23,7 @@ namespace Chernobyl_Relay_Chat
         private static readonly Dictionary<string, string> channelLangs = new Dictionary<string, string>()
         {
             ["#crc_english"] = "eng",
-            ["#crc_english_rp"] = "eng",
-            ["#crc_english_shitposting"] = "eng",
-            ["#crc_tech_support"] = "eng",
             ["#crc_russian"] = "rus",
-            ["#crc_russian_rp"] = "rus",
         };
 
         public static void Load()

--- a/Chernobyl Relay Chat/CRCUpdate.cs
+++ b/Chernobyl Relay Chat/CRCUpdate.cs
@@ -14,7 +14,11 @@ namespace Chernobyl_Relay_Chat
 
         public static bool CheckFirstUpdate()
         {
-            UpdateChecker updateChecker = new UpdateChecker("TKGP", "Chernobyl-Relay-Chat");
+            UpdateChecker updateChecker = new UpdateChecker("Thom-Rum", "Chernobyl-Relay-Chat");
+            //Github updatechecker is broken with later versions of octokit.
+            //var client = new GitHubClient(new ProductHeaderValue("crc-updater"));
+            //var UpdateChecker = client.Repository.Release.GetAll("octokit", "octokit.net");
+            //var latest = UpdateChecker[0];
             UpdateType updateType;
             try
             {
@@ -50,7 +54,9 @@ namespace Chernobyl_Relay_Chat
 
         public static async Task<bool> CheckUpdate()
         {
-            UpdateChecker updateChecker = new UpdateChecker("TKGP", "Chernobyl-Relay-Chat");
+            UpdateChecker updateChecker = new UpdateChecker("Thom-Rum", "Chernobyl-Relay-Chat");
+            //throws error with later versions of Octokit
+            //Method not found: 'Octokit.IReleasesClient Octokit.GitHubClient.get_Release()
             UpdateType updateType;
             try
             {

--- a/Chernobyl Relay Chat/Chernobyl Relay Chat.csproj
+++ b/Chernobyl Relay Chat/Chernobyl Relay Chat.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Chernobyl_Relay_Chat</RootNamespace>
     <AssemblyName>Chernobyl Relay Chat</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -43,28 +44,26 @@
       <HintPath>..\packages\GitHubUpdate.1.2.0.0\lib\net45\GitHubUpdate.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=2.0.7.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.7\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.14.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.14\lib\net45\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Meebey.SmartIrc4net, Version=0.5.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\smartirc4net-2015.0.5.9\lib\net40\Meebey.SmartIrc4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Meebey.SmartIrc4net, Version=0.4.5.0, Culture=neutral, PublicKeyToken=7868485fbf407e0f, processorArchitecture=MSIL">
+      <HintPath>..\packages\SmartIrc4net.1.1\lib\Meebey.SmartIrc4net.dll</HintPath>
     </Reference>
-    <Reference Include="Octokit, Version=0.3.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octokit.0.3.4\lib\net45\Octokit.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Octokit, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octokit.0.6.2\lib\net45\Octokit.dll</HintPath>
     </Reference>
-    <Reference Include="Semver, Version=1.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\semver.1.1.2\lib\net451\Semver.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Semver, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Semver.2.1.0\lib\net452\Semver.dll</HintPath>
     </Reference>
     <Reference Include="StarkSoftProxy, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\smartirc4net-2015.0.5.9\lib\net40\StarkSoftProxy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -149,6 +148,7 @@
     <Compile Include="Properties\Resources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
     </Compile>
     <EmbeddedResource Include="UpdateForm.resx">
       <DependentUpon>UpdateForm.cs</DependentUpon>

--- a/Chernobyl Relay Chat/Program.cs
+++ b/Chernobyl Relay Chat/Program.cs
@@ -36,8 +36,8 @@ namespace Chernobyl_Relay_Chat
                 return;
             }
 
-            if (CRCUpdate.CheckFirstUpdate())
-                return;
+        //    if (CRCUpdate.CheckFirstUpdate())
+        //        return;
 
             displayThread = new Thread(CRCDisplay.Start);
             displayThread.Start();

--- a/Chernobyl Relay Chat/Properties/Resources.Designer.cs
+++ b/Chernobyl Relay Chat/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Chernobyl_Relay_Chat.Properties
-{
-
-
+namespace Chernobyl_Relay_Chat.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace Chernobyl_Relay_Chat.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Chernobyl_Relay_Chat.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/Chernobyl Relay Chat/Properties/Settings.Designer.cs
+++ b/Chernobyl Relay Chat/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace Chernobyl_Relay_Chat.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.1.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Chernobyl Relay Chat/packages.config
+++ b/Chernobyl Relay Chat/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="GitHubUpdate" version="1.2.0.0" targetFramework="net452" />
-  <package id="log4net" version="2.0.7" targetFramework="net452" />
-  <package id="Octokit" version="0.3.4" targetFramework="net452" />
-  <package id="semver" version="1.1.2" targetFramework="net452" />
+  <package id="log4net" version="2.0.14" targetFramework="net48" />
+  <package id="Octokit" version="0.6.2" targetFramework="net48" />
+  <package id="Semver" version="2.1.0" targetFramework="net48" />
+  <package id="SmartIrc4net" version="1.1" targetFramework="net48" />
   <package id="smartirc4net-2015" version="0.5.9" targetFramework="net452" />
 </packages>

--- a/gamedata/configs/ui/crc_chatbox.xml
+++ b/gamedata/configs/ui/crc_chatbox.xml
@@ -3,28 +3,32 @@
 	<background x="0" y="0" width="1024" height="768" stretch="1">
 		<texture>ui\crc_log_background</texture>
 	</background>
-	
-	<button_channel x="5" y="5" width="104" height="28" stretch="1">
-		<texture>ui_inGame2_Mp_bigbuttone</texture>
-		<text font="letterica18" align="c"/>
-		<text_color>
-			<e r="200" g="200" b="200"/>
-		</text_color>
-	</button_channel>
-	
-	<edit_box x="10" y="705" width="1004" height="24">
-		<texture>ui_inGame2_edit_box_1</texture>
-		<text x="3" font="letterica18" vert_align="c"/>
+		
+	<edit_box x="20" y="718" width="984" height="30">
+		<texture>ui_linetext_e</texture>
+		<text x="10" font="letterica18" r="240" g="217" b="182"/>
 	</edit_box>
 	
-	<button_send x="837" y="734" width="86" height="24" stretch="1">
-		<texture>ui_inGame2_button</texture>
+	<button_send x="750" y="668" width="117" height="29">
+		<texture>ui_button_ordinary</texture>
 		<text font="letterica18" align="c">crc_send</text>
+		<text_color>
+			<e r="227" g="199" b="178"/>
+			<t r="180" g="153" b="155"/>
+			<d r="106" g=" 95" b=" 91"/>
+			<h r="  0" g="  0" b="  0"/>
+		</text_color>
 	</button_send>
 	
-	<button_close x="928" y="734" width="86" height="24" stretch="1">
-		<texture>ui_inGame2_button</texture>
+	<button_close x="887" y="668" width="117" height="29">
+		<texture>ui_button_ordinary</texture>
 		<text font="letterica18" align="c">crc_close</text>
+		<text_color>
+			<e r="227" g="199" b="178"/>
+			<t r="180" g="153" b="155"/>
+			<d r="106" g=" 95" b=" 91"/>
+			<h r="  0" g="  0" b="  0"/>
+		</text_color>
 	</button_close>
 	
 	<user x="0" y="20" width="1024" height="39">

--- a/readme (english).txt
+++ b/readme (english).txt
@@ -1,7 +1,7 @@
---| Chernobyl Relay Chat
+--| Call of Chernobyl Relay Chat
 --| Version 0.8.1
 --| By Thom-Rum
---| https://github.com/Thom-Rum/Chernobyl-Relay-Chat
+--| https://github.com/Thom-Rum/Call-Of-Chernobyl-Relay-Chat/
 
 
 An integrated chat client for Call of Chernobyl 1.4.12 or later, with any and all addons.
@@ -9,7 +9,6 @@ An integrated chat client for Call of Chernobyl 1.4.12 or later, with any and al
 Bug reports and suggestions should be raised in the Github Repository under issues, or discussions.
 
 Original work was done by TKGP, and all credit and glory goes to them. Uplift to newer dotnet and nuget versions was done by Thom-Rum.
-
 
 
 

--- a/readme (english).txt
+++ b/readme (english).txt
@@ -1,11 +1,16 @@
-
 --| Chernobyl Relay Chat
---| Version 0.5.0
---| By TKGP
---| https://github.com/TKGP/Chernobyl-Relay-Chat
+--| Version 0.8.1
+--| By Thom-Rum
+--| https://github.com/Thom-Rum/Chernobyl-Relay-Chat
+
 
 An integrated chat client for Call of Chernobyl 1.4.12 or later, with any and all addons.
-Bug reports and suggestions may submitted as issues on GitHub or via email to: contact.tkgp@gmail.com
+.NET and Nuget packages have been uplifted, and Libera Chat IRC is now used.
+Bug reports and suggestions should be raised in the Github Repository under issues, or discussions.
+
+Original work was done by TKGP, and all credit and glory goes to them. Uplift to newer dotnet and nuget versions was done by Thom-Rum.
+
+
 
 
 --| Installation
@@ -24,6 +29,8 @@ You may use text commands from the game or client by starting with a /. Use /com
 
 --| Credits
 
+
+Chernobyl Relay Chat: TKGP
 GitHub: Octokit
 Max Hauser: semver
 Mirco Bauer: SmartIrc4Net


### PR DESCRIPTION
- Uplifted from .NET Framework 4.5.2 to the latest -> 4.8.
- Uplifted most Nuget packages, except for Octokit. GithubUpdate relies on old Octokit functions that have been changed over the years.
- Switched to Libera chat
- Removed some IRC channels till I can test things and figure out which channels I want to maintain.
- Renamed the project to CoCRelayChat in order to avoid confusing it with Chernobyl Relay Chat Rebirth. 